### PR TITLE
docs(troubleshooting): drops obsolete dependencies

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,7 +45,7 @@ machine to check which dependencies are missing. The common ones are provided be
 <summary>Debian (e.g. Ubuntu) Dependencies</summary>
 
 ```
-gconf-service
+libappindicator3-1
 libasound2
 libatk1.0-0
 libatk-bridge2.0-0
@@ -56,8 +56,6 @@ libdbus-1-3
 libexpat1
 libfontconfig1
 libgcc1
-libgconf-2-4
-libgdk-pixbuf2.0-0
 libglib2.0-0
 libgtk-3-0
 libnspr4
@@ -79,7 +77,6 @@ libxss1
 libxtst6
 ca-certificates
 fonts-liberation
-libappindicator1
 libnss3
 lsb-release
 xdg-utils
@@ -101,7 +98,6 @@ libXtst.x86_64
 cups-libs.x86_64
 libXScrnSaver.x86_64
 libXrandr.x86_64
-GConf2.x86_64
 alsa-lib.x86_64
 atk.x86_64
 gtk3.x86_64


### PR DESCRIPTION
It looks like chromium dropped gconf in 2017, while at it remove
some other libs from the gtk2 era and bump libappindicator to a gtk3
version.

Current dependencies list for chromium 79 used as reference:
https://chromium.googlesource.com/chromium/src.git/+/refs/tags/79.0.3945.144/build/install-build-deps.sh#232